### PR TITLE
Small fix to gulpfile.js and fix for undefined error in keywords

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,7 +58,7 @@ gulp.task('watch', function() {
 
   gulp.watch(paths.sassFiles, ['sass']);
 
-  gulp.watch('static/scripts/**/*.js', ['script']);
+  gulp.watch(paths.scriptFiles, ['script']);
 
   gulp.watch('**/*.html', ['html']);
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,7 +58,7 @@ gulp.task('watch', function() {
 
   gulp.watch(paths.sassFiles, ['sass']);
 
-  gulp.watch('static/scripts', ['script']);
+  gulp.watch('static/scripts/**/*.js', ['script']);
 
   gulp.watch('**/*.html', ['html']);
 

--- a/static/scripts/helper/loadKeywords.js
+++ b/static/scripts/helper/loadKeywords.js
@@ -1,15 +1,14 @@
 define(['underscore'], function(_) {
 
   var loadKeywords = function loadKeywords() {
-    console.log('keywords')
+    console.log('keywords');
     _.each($('.article-list-item-keywords'), function(obj) {
       var keywordsUrl = $(obj).attr('keywords-url');
-
       $.ajax({
         url: keywordsUrl,
         dataType: 'json',
         success: function(json) {
-          if (json.keywords[0]) {
+          if (json.keywords && json.keywords[0]) {
             $(obj).removeClass('hidden').append(json.keywords[0].value);
           }
         },
@@ -18,7 +17,7 @@ define(['underscore'], function(_) {
         }
       });
     });
-  }
+  };
 
   return {
     loadKeywords: loadKeywords


### PR DESCRIPTION
Noticed the watch task in gulp wasn't looking for the scripts path in the gulpfile, and added an additional check for the keywords object in the ajax response to fix the 'cannot read property 0 from undefined error' that showed up when the keywords script would run.